### PR TITLE
Removed Karma mention from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,6 @@ See [open test framework support issues](https://github.com/RyzacInc/console-fai
       </td>
     </tr>
     <tr>
-      <td>Karma</td>
-      <td>
-        <span aria-label="not yet supported" role="img">⚙️</span>
-      </td>
-      <td>
-        <a href="https://github.com/RyzacInc/console-fail-test/issues/6">
-          <code>/issues/6</code>
-        </a>
-      </td>
-    </tr>
-    <tr>
       <td>lab</td>
       <td>
         <span aria-label="not yet supported" role="img">⚙️</span>


### PR DESCRIPTION
Karma just runs other test frameworks, so this makes sense to remove.

Fixes #6.