### PR TITLE
Allowed specifying frameworks and libraries with their modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ require("console-fail-test").cft({
 ### Test Frameworks
 
 Test frameworks that are ✨ auto-detectable can be supported by just running `console-fail-test/setup.js` before tests.
-For others, use the Node API with their API name:
+For others, use the Node API with their API request:
 
 ```js
 require("console-fail-test").cft({
-    testFramework: "ava",
+    testFramework: require("ava"),
 });
 ```
 
@@ -36,7 +36,7 @@ require("console-fail-test").cft({
     <tr>
       <td>Framework</td>
       <td>Support?</td>
-      <td>API Name</td>
+      <td>API Request</td>
       <td>Documentation</td>
     </tr>
   </thead>
@@ -164,7 +164,7 @@ require("console-fail-test").cft({
 
 If a supported spy library isn't detected, an internal fallback will be used to spy on `console` methods.
 
-You can request a specific test library using the Node API with its API name:
+You can request a specific test library using the Node API with its API request:
 
 ```js
 require("console-fail-test").cft({
@@ -177,7 +177,7 @@ require("console-fail-test").cft({
     <tr>
       <td>Library</td>
       <td>Support?</td>
-      <td>API Name</td>
+      <td>API Request</td>
       <td>Spy</td>
       <td>Documentation</td>
     </tr>
@@ -227,7 +227,7 @@ require("console-fail-test").cft({
         <span aria-label="supported" role="img">✅️</span>
       </td>
       <td>
-        <code>"sinon"</code>
+        <code>require("sinon")</code>
       </td>
       <td>
         <a href="https://sinonjs.org/releases/latest/spies">

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -32,9 +32,9 @@ If you use a test framework console-fail-test doesn't yet support:
 
 1. Find or file an issue tagged with [test framework support](https://github.com/RyzacInc/console-fail-test/issues?q=is%3Aissue+is%3Aopen+label%3A%22test+framework+support%22) and wait until it's marked as [accepting prs](https://github.com/RyzacInc/console-fail-test/labels/accepting%20prs)
 2. Add a new file under [`src/environments`](../src/environments) that exports a function matching `TestEnvironmentGetter`:
-    - If the environment doesn't seem to exist, return `undefined`
-    - If the environment does seem to exist, return an object with hooks to be called by [`cft.ts`](../src/cft.ts)
-3. Add that failer to `allTestEnvironments` in [`src/environments/allTestEnvironments.ts`](../src/environments/allTestEnvironments.ts)
+    - If the environment isn't provided and doesn't seem to exist, return `undefined`
+    - If the environment is provided or does seem to exist, return an object with hooks to be called by [`cft.ts`](../src/cft.ts)
+3. Add that getter to `testEnvironmentsByName` and `detectableTestEnvironmentGetters` in [`src/environments/selectTestEnvironment.ts`](../src/environments/selectTestEnvironment.ts)
 
 See [`src/environments/jest.ts`](../src/environments/jest.ts) as an example.
 
@@ -49,10 +49,11 @@ For example, if `jest` and `jest.fn` are available, it's assumed that Jest's spi
 If you use a spy library console-fail-test doesn't yet support:
 
 1. Find or file an issue tagged with [spy library support](https://github.com/RyzacInc/console-fail-test/issues?q=is%3Aissue+is%3Aopen+label%3A%22spy+library+support%22) and wait until it's marked as [accepting prs](https://github.com/RyzacInc/console-fail-test/labels/accepting%20prs)
-2. Add a new file under [`src/spies`](../src/spies) that exports an object matching `SpyFactory`:
-    - `canSpy`: returns whether this spy type is globally available
-    - `spyOn`: given a container object and a method name available on that container, spies on that method on the container
+2. Add a new file under [`src/spies`](../src/spies) that exports a function matching matching `SpyFactoryGetter`:
+    - If the spy library isn't provided and doesn't seem to exist, return `undefined`
+    - If the spy library is provided or does seem to exist, return a method that, given a container object and method name, spies on that method on the container
+3. Add that getter to `spyFactoriesByName` and `detectableSpyFactoryGetters` in [src/spies/selectSpyFactory.ts](../src/spies/selectSpyFactory.ts).
 
-The object containing `getCalls` and `restore` returned by `spyOn` will be used by [`cft.ts`](../src/cft.ts) to check whether the method was called.
+The returned object containing `getCalls` and `restore` returned by `spyOn` will be used by [`cft.ts`](../src/cft.ts) to check whether the method was called.
 
 See [`src/spies/jest.ts`](../src/spies/jest.ts) as an example.

--- a/docs/Mocha.md
+++ b/docs/Mocha.md
@@ -16,5 +16,5 @@ Alternately, if you have a setup file already being run first, or you'd like to 
 ```js
 // some.test.js
 
-require("console-fail-test").ctf();
+require("console-fail-test").cft();
 ```

--- a/docs/Sinon.md
+++ b/docs/Sinon.md
@@ -3,8 +3,13 @@
 Sinon is supported as a spy library.
 It will be auto-detected if `sinon.spy` is globally available.
 
-> If `sinon.spy` is not globally available without `import` or `require` calls,
-> it will not be used!
+Otherwise, pass `require("sinon")` as your `spyLibrary` request:
+
+```js
+require("console-fail-test").cft({
+    spyLibrary: require("sinon"),
+});
+```
 
 ## Spies
 

--- a/src/cft.ts
+++ b/src/cft.ts
@@ -12,7 +12,7 @@ export const cft = (request: CftRequest = {}) => {
 
     testEnvironment.before(() => {
         for (const methodName of consoleMethodNames) {
-            methodSpies[methodName] = spyFactory.spyOn(console, methodName);
+            methodSpies[methodName] = spyFactory(console, methodName);
         }
     });
 

--- a/src/environments/selectTestEnvironments.ts
+++ b/src/environments/selectTestEnvironments.ts
@@ -22,14 +22,14 @@ const detectableTestEnvironmentGetters: TestEnvironmentGetter[] = [
 ];
 
 export const selectTestEnvironment = (request: CftRequest) => {
-    // If a test environment is requested, it must exist
-    if (request.testFramework !== undefined) {
+    // If a test environment is requested by name, it must exist
+    if (typeof request.testFramework === "string") {
         const getter = testEnvironmentsByName.get(request.testFramework);
         if (getter === undefined) {
-            throw new Error(`Requested test framework '${request.testFramework}' not supported by console-fail-test.`);
+            throw new Error(`Requested test framework '${request.testFramework}' not known by name in console-fail-test.`);
         }
 
-        const environment = getter();
+        const environment = getter(request);
         if (environment === undefined) {
             throw new Error(`Requested test framework '${request.testFramework}' does not seem to be active.`);
         }
@@ -39,7 +39,7 @@ export const selectTestEnvironment = (request: CftRequest) => {
 
     // Otherwise, attempt to auto-detect an active one
     for (const testEnvironmentGetter of detectableTestEnvironmentGetters) {
-        const environment = testEnvironmentGetter();
+        const environment = testEnvironmentGetter(request);
 
         if (environment !== undefined) {
             return environment;

--- a/src/environments/testEnvironmentTypes.ts
+++ b/src/environments/testEnvironmentTypes.ts
@@ -1,6 +1,7 @@
 import { MethodCall } from "../spies/spyTypes";
+import { CftRequest } from "../types";
 
-export type TestEnvironmentGetter = () => TestEnvironment | undefined;
+export type TestEnvironmentGetter = (request: CftRequest) => TestEnvironment | undefined;
 
 export type TestEnvironment = {
     after: (callback: (hooks: TestAfterHooks) => void) => void;

--- a/src/spies/fallback.ts
+++ b/src/spies/fallback.ts
@@ -2,29 +2,26 @@ import { createStack } from "../stack";
 
 import { MethodCall, SpyFactory } from "./spyTypes";
 
-export const fallbackSpyFactory: SpyFactory = {
-    canSpy: () => true,
-    spyOn(container: any, methodName: string) {
-        const methodCalls: MethodCall[] = [];
-        const originalMethod = container[methodName];
+export const getFallbackSpyFactory = (): SpyFactory => (container: any, methodName: string) => {
+    const methodCalls: MethodCall[] = [];
+    const originalMethod = container[methodName];
 
-        const spyMethod = function(this: unknown, ...args: unknown[]) {
-            methodCalls.push({
-                args,
-                stack: createStack(),
-            });
+    const spyMethod = function(this: unknown, ...args: unknown[]) {
+        methodCalls.push({
+            args,
+            stack: createStack(),
+        });
 
-            return originalMethod.apply(this, args);
-        };
+        return originalMethod.apply(this, args);
+    };
 
-        spyMethod.getCalls = () => methodCalls;
+    spyMethod.getCalls = () => methodCalls;
 
-        spyMethod.restore = () => {
-            container[methodName] = originalMethod;
-        };
+    spyMethod.restore = () => {
+        container[methodName] = originalMethod;
+    };
 
-        container[methodName] = spyMethod;
+    container[methodName] = spyMethod;
 
-        return spyMethod;
-    },
+    return spyMethod;
 };

--- a/src/spies/sinon.ts
+++ b/src/spies/sinon.ts
@@ -1,25 +1,29 @@
 import { createStack } from "../stack";
+import { CftRequest } from "../types";
 
-import { MethodCall, SpyFactory } from "./spyTypes";
+import { MethodCall, SpyFactory, SpyFactoryGetter } from "./spyTypes";
 
 type SinonSpy = Function & {
     getCalls(): unknown[][];
     restore(): void;
 };
 
-declare const sinon: {
+declare type Sinon = {
     spy(callback: Function): SinonSpy;
 };
 
-export const sinonSpyFactory: SpyFactory = {
-    canSpy() {
-        return typeof sinon !== "undefined" && typeof sinon.spy !== "undefined";
-    },
-    spyOn(container: any, methodName: string) {
+declare const sinon: Sinon | undefined;
+
+const isSinonModule = (spyLibrary: unknown): spyLibrary is Sinon => {
+    return typeof spyLibrary === "object" && typeof (spyLibrary as Partial<Sinon>).spy === "function";
+};
+
+const createSinonSpyFactory = (spyLibrary: Sinon): SpyFactory => {
+    return (container: any, methodName: string) => {
         const methodCalls: MethodCall[] = [];
         const originalMethod = container[methodName];
 
-        const spyMethod = sinon.spy(function(this: unknown, ...args: unknown[]) {
+        const spyMethod = spyLibrary.spy(function(this: unknown, ...args: unknown[]) {
             methodCalls.push({
                 args,
                 stack: createStack(),
@@ -36,5 +40,17 @@ export const sinonSpyFactory: SpyFactory = {
                 container[methodName] = originalMethod;
             },
         };
-    },
+    };
+};
+
+export const getSinonSpyFactory: SpyFactoryGetter = ({ spyLibrary }: CftRequest) => {
+    if (isSinonModule(spyLibrary)) {
+        return createSinonSpyFactory(spyLibrary);
+    }
+
+    if (typeof sinon !== "undefined" && isSinonModule(sinon)) {
+        return createSinonSpyFactory(sinon);
+    }
+
+    return undefined;
 };

--- a/src/spies/spyTypes.ts
+++ b/src/spies/spyTypes.ts
@@ -1,19 +1,11 @@
 import { CftRequest } from "../types";
 
+export type SpyFactoryGetter = (request: CftRequest) => SpyFactory | undefined;
+
 /**
  * Creates method spies that abstract the spy library implementation.
  */
-export type SpyFactory = {
-    /**
-     * @returns Whether this spy factory's library is usable (has been loaded).
-     */
-    canSpy(request: CftRequest): boolean;
-
-    /**
-     * Spies on calls to a method on a container by name.
-     */
-    spyOn(container: any, methodName: string): MethodSpy;
-};
+export type SpyFactory = (container: any, methodName: string) => MethodSpy;
 
 /**
  * Record for a single method being spied upon.

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,6 @@ export type CftRequest = {
     testFramework?: SupportedTestFramework;
 };
 
-export type SupportedSpyLibrary = "fallback" | "jasmine" | "jest" | "sinon";
+export type SupportedSpyLibrary = "fallback" | "jasmine" | "jest" | "sinon" | unknown;
 
-export type SupportedTestFramework = "mocha" | "jasmine" | "jest";
+export type SupportedTestFramework = "mocha" | "jasmine" | "jest" | unknown;


### PR DESCRIPTION
This way, you can now specify a module by passing the `require("module")` equivalent as its API name. This will unblock frameworks such as Ava that don't create global variables.

Fixes #26.