### PR TITLE
Added node-tap support

### DIFF
--- a/src/cft.ts
+++ b/src/cft.ts
@@ -37,8 +37,6 @@ export const cft = (request: CftRequest = {}) => {
             return;
         }
 
-        const complaint = testEnvironment.formatComplaint(createComplaint(methodsWithCalls));
-
-        reportComplaint(complaint);
+        reportComplaint(createComplaint(methodsWithCalls));
     });
 };

--- a/src/complaining.ts
+++ b/src/complaining.ts
@@ -1,33 +1,41 @@
+import { TestComplaint } from "./environments/testEnvironmentTypes";
 import { MethodCall } from "./spies/spyTypes";
 
 const lineThreshold = 3;
 
 const formatMethodComplaint = ([methodName, calls]: [keyof Console, MethodCall[]]) => {
-    const summary = `* ${methodName} (${calls.length} call${calls.length === 1 ? "" : "s"})`;
+    const summary = `  * ${methodName} (${calls.length} call${calls.length === 1 ? "" : "s"})`;
 
-    const lines = calls.slice(0, Math.min(calls.length, lineThreshold)).map(formatLine);
+    const lines = calls.slice(0, Math.min(calls.length, lineThreshold)).map(formatComplaintLineWithIndex);
 
     if (calls.length > lineThreshold) {
         lines.push(`...${calls.length - lineThreshold} more`);
     }
 
-    return `${summary}\n${lines.map((line) => `  > Call ${line}`).join("\n")}`;
+    return `${summary}\n${lines.map((line) => `    > Call ${line}`).join("\n")}`;
 };
 
-const formatLine = (call: MethodCall, i: number) => `${i}: ${call.args.map(formatArg)}`;
+export const formatComplaintLineWithIndex = (call: MethodCall, i: number) => `${i}: ${formatComplaintCall(call)}`;
 
-const formatArg = (arg: unknown) => {
+export const formatComplaintCall = (call: MethodCall) => call.args.map(formatComplaintLineArg).join(", ");
+
+export const formatComplaintLineArg = (arg: unknown) => {
     const text = JSON.stringify(arg);
     const endlineMatch = text.match(/\n|(\\n)/);
 
     return endlineMatch === null ? text : `${text.substring(0, endlineMatch.index)}...`;
 };
 
-export const createComplaint = (methodsWithCalls: [keyof Console, MethodCall[]][]) => {
+export const createComplaint = (methodsWithCalls: [keyof Console, MethodCall[]][]): TestComplaint => {
     const methodComplaints = methodsWithCalls.map(formatMethodComplaint).join("\n");
     const s = methodsWithCalls.length === 1 ? "" : "s";
 
     // It looks like something wrote to the console during your test!
     // Put a breakpoint on this line and check the methodsWithCalls variable to see details.
-    return new Error(`Oh no! Your test called the following console method${s}:\n${methodComplaints}`);
+    const error = new Error(`Oh no! Your test called the following console method${s}:\n${methodComplaints}`);
+
+    return {
+        error,
+        methodComplaints: methodsWithCalls.map(([methodName, methodCalls]) => ({ methodName, methodCalls })),
+    };
 };

--- a/src/environments/ava.ts
+++ b/src/environments/ava.ts
@@ -37,17 +37,13 @@ export const getAvaEnvironment: TestEnvironmentGetter = ({ testFramework }: CftR
         after(callback: (afterHooks: TestAfterHooks) => void) {
             testFramework.afterEach(() => {
                 callback({
-                    reportComplaint: (complaint: Error) => {
-                        throw complaint;
+                    reportComplaint: ({ error }) => {
+                        throw error;
                     },
                 });
             });
         },
         before: testFramework.beforeEach,
         filterMethodCalls: ({ methodCalls }) => methodCalls,
-        formatComplaint: (error: Error): Error => {
-            error.message = error.message.replace(/\n/g, "\n  ");
-            return error;
-        },
     };
 };

--- a/src/environments/jasmine.ts
+++ b/src/environments/jasmine.ts
@@ -20,7 +20,11 @@ export const getJasmineEnvironment: TestEnvironmentGetter = () => {
         after(callback: (afterHooks: TestAfterHooks) => void) {
             afterEach(() => {
                 callback({
-                    reportComplaint(error: Error) {
+                    reportComplaint({ error }) {
+                        // Jasmine prints the error stack along with its message, resulting in a duplicate message
+                        // tslint:disable-next-line:no-non-null-assertion
+                        error.stack = error.stack!.substring(error.message.length);
+
                         throw error;
                     },
                 });
@@ -30,11 +34,5 @@ export const getJasmineEnvironment: TestEnvironmentGetter = () => {
             beforeEach(callback);
         },
         filterMethodCalls: ({ methodCalls }) => methodCalls,
-        formatComplaint: (complaint: Error) => {
-            // Jasmine prints the error stack along with its message, resulting in a duplicate message
-            // tslint:disable-next-line:no-non-null-assertion
-            complaint.stack = complaint.stack!.substring(complaint.message.length);
-            return complaint;
-        },
     };
 };

--- a/src/environments/jest.ts
+++ b/src/environments/jest.ts
@@ -13,7 +13,7 @@ export const getJestEnvironment: TestEnvironmentGetter = () => {
         after(callback: (afterHooks: TestAfterHooks) => void) {
             afterEach(() => {
                 callback({
-                    reportComplaint(error: Error) {
+                    reportComplaint({ error }) {
                         throw error;
                     },
                 });
@@ -23,6 +23,5 @@ export const getJestEnvironment: TestEnvironmentGetter = () => {
             beforeEach(callback);
         },
         filterMethodCalls: ({ methodCalls }) => methodCalls,
-        formatComplaint: (complaint: Error) => complaint,
     };
 };

--- a/src/environments/lab.ts
+++ b/src/environments/lab.ts
@@ -31,14 +31,13 @@ export const getLabEnvironment: TestEnvironmentGetter = ({ testFramework }: CftR
         after(callback: (afterHooks: TestAfterHooks) => void) {
             testFramework.afterEach(() => {
                 callback({
-                    reportComplaint: (complaint: Error) => {
-                        throw complaint;
+                    reportComplaint({ error }) {
+                        throw error;
                     },
                 });
             });
         },
         before: testFramework.beforeEach,
         filterMethodCalls: ({ methodCalls }) => methodCalls,
-        formatComplaint: (error: Error): Error => error,
     };
 };

--- a/src/environments/mocha.ts
+++ b/src/environments/mocha.ts
@@ -33,8 +33,9 @@ export const getMochaEnvironment: TestEnvironmentGetter = () => {
                 }
 
                 callback({
-                    reportComplaint: (complaint: Error) => {
-                        this.test.error(complaint);
+                    reportComplaint: ({ error }) => {
+                        error.message = error.message.replace(/\n/g, "\n     ");
+                        this.test.error(error);
                     },
                 });
             });
@@ -55,10 +56,6 @@ export const getMochaEnvironment: TestEnvironmentGetter = () => {
             }
 
             return methodCalls;
-        },
-        formatComplaint: (error: Error): Error => {
-            error.message = error.message.replace(/\n/g, "\n       ");
-            return error;
         },
     };
 };

--- a/src/environments/nodeTap.ts
+++ b/src/environments/nodeTap.ts
@@ -1,0 +1,55 @@
+import { formatComplaintCall } from "../complaining";
+import { CftRequest } from "../types";
+
+import { TestAfterHooks, TestEnvironmentGetter } from "./testEnvironmentTypes";
+
+declare type NodeTap = {
+    afterEach(callback: Function): void;
+    beforeEach(callback: Function): void;
+    fail(message: string): void;
+    jobs: number;
+    pool: {};
+    name: "TAP";
+};
+
+const isNodeTap = (testFramework: unknown): testFramework is NodeTap => {
+    return (
+        typeof testFramework !== "undefined" &&
+        typeof (testFramework as Partial<NodeTap>).afterEach === "function" &&
+        typeof (testFramework as Partial<NodeTap>).beforeEach === "function" &&
+        typeof (testFramework as Partial<NodeTap>).fail === "function" &&
+        typeof (testFramework as Partial<NodeTap>).jobs === "number" &&
+        typeof (testFramework as Partial<NodeTap>).pool === "object" &&
+        (testFramework as Partial<NodeTap>).name === "TAP"
+    );
+};
+
+export const getNodeTapEnvironment: TestEnvironmentGetter = ({ testFramework }: CftRequest) => {
+    if (!isNodeTap(testFramework)) {
+        return undefined;
+    }
+
+    return {
+        after(callback: (afterHooks: TestAfterHooks) => void) {
+            testFramework.afterEach((onFinishAfterEach: () => void) => {
+                callback({
+                    reportComplaint({ methodComplaints }) {
+                        for (const { methodName, methodCalls } of methodComplaints) {
+                            for (const methodCall of methodCalls) {
+                                testFramework.fail(`console.${methodName} was called with: ${formatComplaintCall(methodCall)}`);
+                            }
+                        }
+                    },
+                });
+                onFinishAfterEach();
+            });
+        },
+        before(callback: () => void) {
+            testFramework.beforeEach((onFinishBeforeEach: () => void) => {
+                callback();
+                onFinishBeforeEach();
+            });
+        },
+        filterMethodCalls: ({ methodCalls }) => methodCalls,
+    };
+};

--- a/src/environments/selectTestEnvironments.ts
+++ b/src/environments/selectTestEnvironments.ts
@@ -5,6 +5,7 @@ import { getJasmineEnvironment } from "./jasmine";
 import { getJestEnvironment } from "./jest";
 import { getLabEnvironment } from "./lab";
 import { getMochaEnvironment } from "./mocha";
+import { getNodeTapEnvironment } from "./nodeTap";
 import { TestEnvironmentGetter } from "./testEnvironmentTypes";
 
 const testEnvironmentsByName = new Map<SupportedTestFramework, TestEnvironmentGetter>([
@@ -17,6 +18,7 @@ const detectableTestEnvironmentGetters: TestEnvironmentGetter[] = [
     // These environments only work with received modules, so they should come first
     getAvaEnvironment,
     getLabEnvironment,
+    getNodeTapEnvironment,
 
     // Jest should come before Jasmine because Jest includes a monkey-patched Jasmine
     getJestEnvironment,

--- a/src/environments/testEnvironmentTypes.ts
+++ b/src/environments/testEnvironmentTypes.ts
@@ -6,15 +6,25 @@ export type TestEnvironmentGetter = (request: CftRequest) => TestEnvironment | u
 export type TestEnvironment = {
     after: (callback: (hooks: TestAfterHooks) => void) => void;
     before: (callback: () => void) => void;
-    filterMethodCalls: (filter: TestMethodFilter) => MethodCall[];
-    formatComplaint: (complaint: Error) => Error;
+    filterMethodCalls: (filter: MethodCallsAndName) => MethodCall[];
 };
 
 export type TestAfterHooks = {
-    reportComplaint: (complaint: Error) => void;
+    reportComplaint: (complaint: TestComplaint) => void;
 };
 
-export type TestMethodFilter = {
+export type MethodCallsAndName = {
     methodCalls: MethodCall[];
     methodName: string;
+};
+
+/**
+ * @remarks
+ * It is preferred for test frameworks to directly throw `error`, as it contains a friendly call stack.
+ * However, if the test framework doesn't format multiline error messages well, it might instead
+ * log a separate failure for each of the `methodComplaints`.
+ */
+export type TestComplaint = {
+    error: Error;
+    methodComplaints: MethodCallsAndName[];
 };


### PR DESCRIPTION
node-tap doesn't support multiline error messages; it instead allows for a `.fail(message, extra)` API. This change refactors and somewhat simplifies existing test environments to receive both the formatted `error` and raw method names -> calls in their `reportComplaint` callback. Most just throw the error; node-tap issues a failure for each method call. Fine.

Fixes #18.