### PR TITLE
Started persisting src/ dir after builds in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,20 +8,20 @@ jobs:
 
         steps:
             - checkout
-
             - restore_cache:
                   keys:
                       - dependency-cache-{{ checksum "yarn.lock" }}
                       - dependency-cache-
-
             - run: yarn
-
             - save_cache:
                   paths:
                       - node_modules
                   key: dependency-cache-{{ checksum "yarn.lock" }}
-
             - run: yarn run verify
+            - persist_to_workspace:
+                  root: "."
+                  paths:
+                      - src
 
     publish:
         docker:
@@ -31,11 +31,9 @@ jobs:
 
         steps:
             - checkout
-
             - run:
                   name: Add NPM auth token file
                   command: echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
-
             - run:
                   name: npm publish if new version
                   command: |
@@ -52,6 +50,3 @@ workflows:
                   context: org-global
                   requires:
                       - build
-                  filters:
-                      branches:
-                          only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,8 @@ jobs:
 
         steps:
             - checkout
+            - attach_workspace:
+                  at: "."
             - run:
                   name: Add NPM auth token file
                   command: echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,3 +52,6 @@ workflows:
                   context: org-global
                   requires:
                       - build
+                  filters:
+                      branches:
+                          only: master

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
         "prettier:write:all": "yarn run prettier:write ./{.,src}/**/*.{json,md,ts,yml}",
         "verify": "run-s compile lint"
     },
-    "version": "0.1.0",
+    "version": "0.1.1-beta0",
     "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
         "prettier:write:all": "yarn run prettier:write ./{.,src}/**/*.{json,md,ts,yml}",
         "verify": "run-s compile lint"
     },
-    "version": "0.1.1-beta0",
+    "version": "0.1.1-beta1",
     "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
         "prettier:write:all": "yarn run prettier:write ./{.,src}/**/*.{json,md,ts,yml}",
         "verify": "run-s compile lint"
     },
-    "version": "0.1.1-beta1",
+    "version": "0.1.1",
     "dependencies": {}
 }


### PR DESCRIPTION
Packages don't yet have the new .js files under the src/ directory, because they're not persisted to the workspace for publishing.