### PR TITLE
Adds a console config object to ignore methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,18 @@ require("console-fail-test").cft({
   </tbody>
 </table>
 
+## Ignoring `console` methods
+
+By default, `console-fail-test` will error on _any_ called `console` method. If you'd like ignore certain methods, pass a `console` object to the `cft` API when you set it up:
+
+```js
+require("console-fail-test").cft({
+    console: {
+        warn: false, // won't error on any instance of console.warn
+    },
+});
+```
+
 ## Why?
 
 Logging to the console during tests can be a sign of

--- a/src/cft.ts
+++ b/src/cft.ts
@@ -6,12 +6,12 @@ import { MethodCall, MethodSpy } from "./spies/spyTypes";
 import { CftRequest } from "./types";
 import { setDefaults } from "./defaults";
 
-export const cft = (_request: Partial<CftRequest>) => {
-    const request = setDefaults(_request);
+export const cft = (rawRequest: Partial<CftRequest>) => {
+    const request = setDefaults(rawRequest);
     const spyFactory = getSpyFactory(request);
     const testEnvironment = selectTestEnvironment(request);
     const methodSpies: { [i: string]: MethodSpy } = {};
-    const relevantMethodNames = consoleMethodNames.filter((name) => !!request.console[name as keyof typeof request.console]);
+    const relevantMethodNames = consoleMethodNames.filter((name) => !!request.console[name]);
 
     testEnvironment.before(() => {
         for (const methodName of relevantMethodNames) {

--- a/src/console.ts
+++ b/src/console.ts
@@ -1,7 +1,7 @@
-import { ConsoleObject } from "./types";
+import { ConsoleSettings } from "./types";
 
 const isValidMemberName = (methodName: string) => !methodName.startsWith("_") && methodName[0].toLowerCase() === methodName[0];
 
-export const consoleMethodNames: (keyof ConsoleObject)[] = (Object.keys(console) as (keyof Console)[])
+export const consoleMethodNames: (keyof ConsoleSettings)[] = (Object.keys(console) as (keyof Console)[])
     .filter((methodName) => isValidMemberName(methodName) && typeof console[methodName] === "function")
     .sort();

--- a/src/console.ts
+++ b/src/console.ts
@@ -1,5 +1,7 @@
+import { ConsoleObject } from "./types";
+
 const isValidMemberName = (methodName: string) => !methodName.startsWith("_") && methodName[0].toLowerCase() === methodName[0];
 
-export const consoleMethodNames = (Object.keys(console) as (keyof Console)[])
+export const consoleMethodNames: (keyof ConsoleObject)[] = (Object.keys(console) as (keyof Console)[])
     .filter((methodName) => isValidMemberName(methodName) && typeof console[methodName] === "function")
     .sort();

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -4,6 +4,6 @@ const defaults = {
     console: {},
 };
 
-export const setDefaults = (request: Partial<CftRequest> = {}) => {
+export const setDefaults = (request: Partial<CftRequest> = {}): CftRequest => {
     return { ...defaults, ...request };
 };

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,0 +1,9 @@
+import { CftRequest } from "./types";
+
+const defaults = {
+    console: {},
+};
+
+export const setDefaults = (request: Partial<CftRequest> = {}) => {
+    return { ...defaults, ...request };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type CftRequest = {
+    console: ConsoleObject;
     spyLibrary?: SupportedSpyLibrary;
     testFramework?: SupportedTestFramework;
 };
@@ -6,3 +7,5 @@ export type CftRequest = {
 export type SupportedSpyLibrary = "fallback" | "jasmine" | "jest" | "sinon" | unknown;
 
 export type SupportedTestFramework = "mocha" | "jasmine" | "jest" | unknown;
+
+export type ConsoleObject = { [P in keyof Console]?: Console[P] extends Function ? boolean : never };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export type CftRequest = {
-    console: ConsoleObject;
+    console: ConsoleSettings;
     spyLibrary?: SupportedSpyLibrary;
     testFramework?: SupportedTestFramework;
 };
@@ -8,4 +8,4 @@ export type SupportedSpyLibrary = "fallback" | "jasmine" | "jest" | "sinon" | un
 
 export type SupportedTestFramework = "mocha" | "jasmine" | "jest" | unknown;
 
-export type ConsoleObject = { [P in keyof Console]?: Console[P] extends Function ? boolean : never };
+export type ConsoleSettings = { [P in keyof Console]?: Console[P] extends Function ? boolean : never };


### PR DESCRIPTION
This fixes https://github.com/Codecademy/console-fail-test/issues/35 (and to a lesser extent https://github.com/Codecademy/console-fail-test/issues/36 - not exactly, but enough that I can keep working). 

Supports passing of a `console` object to the `cft` API. `console` object takes a list of key/values where the key is a `console` function and the value is a boolean to error on that function or not. Example: 
```js
require("console-fail-test").cft({
    console: {
        warn: false, // won't error on any instance of console.warn
    },
});
```

