### PR TITLE
(v0.1.3) Added explicit yarn run compile to publish task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
             - checkout
             - attach_workspace:
                   at: "."
+            - run: yarn run compile
             - run:
                   name: Add NPM auth token file
                   command: echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
         "prettier:write:all": "yarn run prettier:write ./{.,src}/**/*.{json,md,ts,yml}",
         "verify": "run-s compile lint"
     },
-    "version": "0.1.2",
+    "version": "0.1.3",
     "dependencies": {}
 }


### PR DESCRIPTION
Corresponding .js files aren't being updating. This manually compiles them in the workspace, in case the existing workspace doesn't include results from the first compile step.