### PR TITLE
Invert the ignore warning condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,12 +254,12 @@ require("console-fail-test").cft({
 
 ## Ignoring `console` methods
 
-By default, `console-fail-test` will error on _any_ called `console` method. If you'd like ignore certain methods, pass a `console` object to the `cft` API when you set it up:
+By default, `console-fail-test` will error on _any_ called `console` method. If you'd like allow certain methods, pass a `console` object to the `cft` API when you set it up:
 
 ```js
 require("console-fail-test").cft({
     console: {
-        warn: false, // won't error on any instance of console.warn
+        warn: true, // won't error on any instance of console.warn
     },
 });
 ```

--- a/src/cft.ts
+++ b/src/cft.ts
@@ -11,7 +11,7 @@ export const cft = (rawRequest: Partial<CftRequest>) => {
     const spyFactory = getSpyFactory(request);
     const testEnvironment = selectTestEnvironment(request);
     const methodSpies: { [i: string]: MethodSpy } = {};
-    const relevantMethodNames = consoleMethodNames.filter((name) => !!request.console[name]);
+    const relevantMethodNames = consoleMethodNames.filter((name) => !request.console[name]);
 
     testEnvironment.before(() => {
         for (const methodName of relevantMethodNames) {


### PR DESCRIPTION
Found a bug where we were only failing methods when they were explicitly set to `true` in the `console` object. Booleans are hard. This inverts the logic; now we allow a method if you set it to true in the `console` object and fail on everything else. 