### PR TITLE
Default to stringified arg in formatComplaintLineArg

### DIFF
--- a/src/complaining.ts
+++ b/src/complaining.ts
@@ -20,7 +20,7 @@ export const formatComplaintLineWithIndex = (call: MethodCall, i: number) => `${
 export const formatComplaintCall = (call: MethodCall) => call.args.map(formatComplaintLineArg).join(", ");
 
 export const formatComplaintLineArg = (arg: unknown) => {
-    const text = JSON.stringify(arg);
+    const text = JSON.stringify(arg) ?? JSON.stringify(`${arg}`);
     const endlineMatch = text.match(/\n|(\\n)/);
 
     return endlineMatch === null ? text : `${text.substring(0, endlineMatch.index)}...`;


### PR DESCRIPTION
It's expected to be stringified when passed to `JSON.parse` anyway, so this makes sure that won't crash. In the case of something like `Error` that becomes `undefined`, we can at least try to stringify it normally.

Fixes #58.